### PR TITLE
Add namespace declaration to fix installation

### DIFF
--- a/de_novo_scilife/__init__.py
+++ b/de_novo_scilife/__init__.py
@@ -1,0 +1,1 @@
+__import__('pkg_resources').declare_namespace(__name__)


### PR DESCRIPTION
```
(denovo)mario@milou2 ~/de_novo_scilife (master)$ python setup.py develop
running develop
running egg_info
creating de_novo_scilife.egg-info
writing de_novo_scilife.egg-info/PKG-INFO
writing namespace_packages to de_novo_scilife.egg-info/namespace_packages.txt
writing top-level names to de_novo_scilife.egg-info/top_level.txt
writing dependency_links to de_novo_scilife.egg-info/dependency_links.txt
writing manifest file 'de_novo_scilife.egg-info/SOURCES.txt'
error: Namespace package problem: de_novo_scilife is a namespace package, but its
__init__.py does not call declare_namespace()! Please fix it.
(See the setuptools manual under "Namespace Packages" for details.)
```
